### PR TITLE
style(stream): 스트리밍 목록, 생성, 상세 페이지 스타일링

### DIFF
--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -16,7 +16,7 @@ const ItemDetail: NextPage = () => {
         </div>
         <div className="mt-5">
           <h1 className="text-3xl font-bold text-gray-900">Galaxy S50</h1>
-          <span className="text-3xl block mt-3 text-gray-900">$140</span>
+          <span className="text-2xl block mt-3 text-gray-900">$140</span>
           <p className="text-base my-6 text-gray-700">
             Lorem Ipsum is simply dummy text of the printing and typesetting
             industry. Lorem Ipsum has been the industry&apos;s standard dummy

--- a/pages/items/upload.tsx
+++ b/pages/items/upload.tsx
@@ -1,11 +1,17 @@
-import type { NextPage } from 'next';
+import type { NextPage } from "next";
 
 const Upload: NextPage = () => {
   return (
-    <div className="px-4 py-10">
-      <div className="my-5">
+    <div className="px-4 space-y-5 py-10">
+      <div>
         <label className="w-full cursor-pointer text-gray-600 hover:border-orange-500 hover:text-orange-500 flex items-center justify-center border-2 border-dashed border-gray-300 h-48 rounded-md">
-          <svg className="h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+          <svg
+            className="h-12 w-12"
+            stroke="currentColor"
+            fill="none"
+            viewBox="0 0 48 48"
+            aria-hidden="true"
+          >
             <path
               d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
               strokeWidth={2}
@@ -16,16 +22,37 @@ const Upload: NextPage = () => {
           <input className="hidden" type="file" />
         </label>
       </div>
-      <div className="my-5">
-        <label className="mb-1 block text-sm font-medium text-gray-700">Price</label>
-        <div className="rounded-md relative flex items-center shadow-sm">
-          <div className="absolute left-0 select-none pl-3 flex items-center justify-center">
+      <div>
+        <label
+          className="mb-1 block text-sm font-medium text-gray-700"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <div className="rounded-md relative flex  items-center shadow-sm">
+          <input
+            id="name"
+            type="email"
+            className="appearance-none w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500"
+            required
+          />
+        </div>
+      </div>
+      <div>
+        <label
+          className="mb-1 block text-sm font-medium text-gray-700"
+          htmlFor="price"
+        >
+          Price
+        </label>
+        <div className="rounded-md relative flex  items-center shadow-sm">
+          <div className="absolute left-0 pointer-events-none pl-3 flex items-center justify-center">
             <span className="text-gray-500 text-sm">$</span>
           </div>
           <input
             id="price"
-            type="text"
             className="appearance-none pl-7 w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500"
+            type="text"
             placeholder="0.00"
           />
           <div className="absolute right-0 pointer-events-none pr-3 flex items-center">
@@ -34,14 +61,21 @@ const Upload: NextPage = () => {
         </div>
       </div>
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700">Description</label>
+        <label
+          htmlFor="description"
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
+          Description
+        </label>
+
         <textarea
-          className="mt-1 shadow-sm w-full focus:ring-orange-500 rounded-md border-gray-300 focus:border-orange-500"
+          id="description"
+          className="mt-1 shadow-sm w-full focus:ring-orange-500 rounded-md border-gray-300 focus:border-orange-500 "
           rows={4}
         />
       </div>
-      <button className="mt-5 w-full bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none">
-        Upload product
+      <button className=" w-full bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none ">
+        Upload item
       </button>
     </div>
   );

--- a/pages/streams/[id].tsx
+++ b/pages/streams/[id].tsx
@@ -4,168 +4,123 @@ const Stream: NextPage = () => {
   return (
     <div className="py-10 px-4 space-y-4">
       <div className="w-full rounded-md shadow-sm bg-slate-300 aspect-video"></div>
-      <h3 className="text-gray-800 font-semibold text-xl mt-2">
-        Let&apos;s try potatos
-      </h3>
-      <div className="py-10 pb-1 h-[50vh] overflow-y-scroll px-4 space-y-4">
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
-        <div className="flex items-start space-x-2">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>Hi how much are you selling them for?</p>
-          </div>
-        </div>
-        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
-          <div className="h-8 w-8 rounded-full bg-slate-400" />
-          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-            <p>I want ₩20,000</p>
-          </div>
-        </div>
+      <div className="mt-5">
+        <h1 className="text-3xl font-bold text-gray-900">Galaxy S50</h1>
+        <span className="text-2xl block mt-3 text-gray-900">$140</span>
+        <p className=" my-6 text-gray-700">
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry&apos;s standard dummy text
+          ever since the 1500s, when an unknown printer took a galley of type
+          and scrambled it to make a type specimen book. It has survived not
+          only five centuries, but also the leap into electronic typesetting,
+          remaining essentially unchanged. It was popularised in the 1960s with
+          the release of Letraset sheets containing Lorem Ipsum passages, and
+          more recently with desktop publishing software like Aldus PageMaker
+          including versions of Lorem Ipsum.
+        </p>
       </div>
-      <div className="fixed py-2 bg-white bottom-0 inset-x-0">
-        <div className="flex relative max-w-md items-center w-full mx-auto">
-          <input
-            type="text"
-            className="shadow-sm rounded-full w-full border-gray-300 focus:ring-orange-500 focus:outline-none focus:border-orange-500 pr-12"
-          />
-          <div className="absolute inset-y-0 flex py-1.5 pr-1.5 right-0">
-            <button
-              className="flex focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 items-center bg-orange-500 rounded-full px-3 hover:bg-orange-600
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Live Chat</h2>
+        <div className="mt-10 pb-16 h-[50vh] overflow-y-scroll px-4 space-y-4">
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-2">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>Hi how much are you selling them for?</p>
+            </div>
+          </div>
+          <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+            <div className="h-8 w-8 rounded-full bg-slate-400" />
+            <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+              <p>I want ₩20,000</p>
+            </div>
+          </div>
+        </div>
+        <div className="fixed w-full mx-auto max-w-md bottom-4 inset-x-0">
+          <div className="flex relative items-center">
+            <input
+              type="text"
+              className="shadow-sm rounded-full w-full border-gray-300 focus:ring-orange-500 focus:outline-none focus:border-orange-500 pr-12"
+            />
+            <div className="absolute inset-y-0 flex py-1.5 pr-1.5 right-0">
+              <button
+                className="flex focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 items-center bg-orange-500 rounded-full px-3 hover:bg-orange-600
             text-sm text-white"
-            >
-              &rarr;
-            </button>
+              >
+                &rarr;
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/pages/streams/[id].tsx
+++ b/pages/streams/[id].tsx
@@ -1,0 +1,176 @@
+import type { NextPage } from "next";
+
+const Stream: NextPage = () => {
+  return (
+    <div className="py-10 px-4 space-y-4">
+      <div className="w-full rounded-md shadow-sm bg-slate-300 aspect-video"></div>
+      <h3 className="text-gray-800 font-semibold text-xl mt-2">
+        Let&apos;s try potatos
+      </h3>
+      <div className="py-10 pb-1 h-[50vh] overflow-y-scroll px-4 space-y-4">
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-2">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>Hi how much are you selling them for?</p>
+          </div>
+        </div>
+        <div className="flex flex-row-reverse space-x-2 space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-slate-400" />
+          <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
+            <p>I want ₩20,000</p>
+          </div>
+        </div>
+      </div>
+      <div className="fixed py-2 bg-white bottom-0 inset-x-0">
+        <div className="flex relative max-w-md items-center w-full mx-auto">
+          <input
+            type="text"
+            className="shadow-sm rounded-full w-full border-gray-300 focus:ring-orange-500 focus:outline-none focus:border-orange-500 pr-12"
+          />
+          <div className="absolute inset-y-0 flex py-1.5 pr-1.5 right-0">
+            <button
+              className="flex focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 items-center bg-orange-500 rounded-full px-3 hover:bg-orange-600
+            text-sm text-white"
+            >
+              &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Stream;

--- a/pages/streams/create.tsx
+++ b/pages/streams/create.tsx
@@ -1,0 +1,65 @@
+import type { NextPage } from "next";
+
+const Create: NextPage = () => {
+  return (
+    <div className="space-y-5 py-10 px-4">
+      <div>
+        <label
+          className="mb-1 block text-sm font-medium text-gray-700"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <div className="rounded-md relative flex  items-center shadow-sm">
+          <input
+            id="name"
+            type="email"
+            className="appearance-none w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500"
+            required
+          />
+        </div>
+      </div>
+      <div>
+        <label
+          className="mb-1 block text-sm font-medium text-gray-700"
+          htmlFor="price"
+        >
+          Price
+        </label>
+        <div className="rounded-md relative flex  items-center shadow-sm">
+          <div className="absolute left-0 pointer-events-none pl-3 flex items-center justify-center">
+            <span className="text-gray-500 text-sm">$</span>
+          </div>
+          <input
+            id="price"
+            className="appearance-none pl-7 w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500"
+            type="text"
+            placeholder="0.00"
+          />
+          <div className="absolute right-0 pointer-events-none pr-3 flex items-center">
+            <span className="text-gray-500">USD</span>
+          </div>
+        </div>
+      </div>
+      <div>
+        <label
+          htmlFor="description"
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
+          Description
+        </label>
+
+        <textarea
+          id="description"
+          className="mt-1 shadow-sm w-full focus:ring-orange-500 rounded-md border-gray-300 focus:border-orange-500 "
+          rows={4}
+        />
+      </div>
+      <button className=" w-full bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none ">
+        Go live
+      </button>
+    </div>
+  );
+};
+
+export default Create;

--- a/pages/streams/index.tsx
+++ b/pages/streams/index.tsx
@@ -1,0 +1,36 @@
+import type { NextPage } from "next";
+
+const Live: NextPage = () => {
+  return (
+    <div className="py-10  divide-y-[1px] space-y-4">
+      {[1, 1, 1, 1, 1, 1].map((_, i) => {
+        return (
+          <div className="pt-4 px-4" key={i}>
+            <div className="w-full rounded-md shadow-sm bg-slate-300 aspect-video"></div>
+            <h3 className="text-gray-900 font-bold text-lg mt-2">
+              Let&apos;s try potatos
+            </h3>
+          </div>
+        );
+      })}
+      <button className="fixed hover:bg-orange-500 transition-colors cursor-pointer bottom-24 right-5 shadow-xl bg-orange-400 rounded-full p-4 border-b-transparent text-white">
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default Live;


### PR DESCRIPTION
## 커밋 내용 요약

- 스트리밍 목록, 상세 페이지, 시작 페이지 추가

## 코드 변경 이유

- 어색한 스타일(패딩, 글자 크기) 수정

## 구현방법 및 변경사항

- 재사용된 코드
  - 스트리밍 목록 페이지
    - home(/index) - 플로팅 버튼
  - 스트리밍 상세 페이지
    - 아이템 상세 페이지 - 제품명, 제품 가격, 제품 설명
    - 스트리밍 목록 - 비디오, 비디오 제목
    - 채팅 상세 페이지 - 채팅 목록, 채팅 입력창
  - 업로드
    - 아이템 업로드 페이지 - 제목 입력창, 가격 입력창, 제품 설명 textarea, 버튼

## 관련 스크린샷

- 스트리밍 시작 페이지 이미지는 아이템 업로드(items/upload)와 중복이 많아 생략

![stream](https://github.com/PanicBear/IWIL-carrot-market/blob/design/img/stream.gif?raw=true)
